### PR TITLE
More convenient way to register grpc service

### DIFF
--- a/service-sdk-macros/Cargo.toml
+++ b/service-sdk-macros/Cargo.toml
@@ -20,3 +20,5 @@ proc-macro = true
 quote = "*"
 
 proc-macro2 = "*"
+
+syn = { version = "*", features = ["full"] }

--- a/service-sdk-macros/src/lib.rs
+++ b/service-sdk-macros/src/lib.rs
@@ -296,23 +296,57 @@ pub fn use_signal_r_subscriber(_input: TokenStream) -> TokenStream {
     .into()
 }
 
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    Ident, Path, Result, Token, Type,
+};
+
+struct GenerateGrpcServiceArgs {
+    service_ident: Ident,
+    app_ty: Type,
+    server_path: Path,
+}
+
+impl Parse for GenerateGrpcServiceArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let service_ident: Ident = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        let app_ty: Type = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        let server_path: Path = input.parse()?;
+
+        Ok(Self { service_ident, app_ty, server_path })
+    }
+}
+
 #[proc_macro]
 pub fn generate_grpc_service(input: TokenStream) -> TokenStream {
-    let input: proc_macro2::TokenStream = input.into();
+    let GenerateGrpcServiceArgs { service_ident, app_ty, server_path } = parse_macro_input!(input as GenerateGrpcServiceArgs);
 
-    quote::quote! {
-
+    let expanded = quote! {
         #[derive(Clone)]
-        pub struct SdkGrpcService {
-            pub app: std::sync::Arc<#input>,
+        pub struct #service_ident {
+            pub app_context: ::std::sync::Arc<#app_ty>,
         }
 
-        impl SdkGrpcService {
-            pub fn new(app: std::sync::Arc<#input>) -> Self {
-                Self { app }
+        impl #service_ident {
+            pub fn new(app_context: ::std::sync::Arc<#app_ty>) -> Self {
+                Self { app_context }
             }
         }
 
-    }
-    .into()
+        impl service_sdk::IntoGrpcServer for #service_ident {
+            type GrpcServer = #server_path<Self>;
+
+            fn into_grpc_server(self) -> Self::GrpcServer {
+                #server_path::new(self)
+            }
+        }
+    };
+
+    expanded.into()
 }

--- a/service-sdk/src/builders/grpc_server_builder.rs
+++ b/service-sdk/src/builders/grpc_server_builder.rs
@@ -14,6 +14,8 @@ use my_logger::LogEventCtx;
 
 use crate::GrpcMetricsMiddlewareLayer;
 
+use crate::IntoGrpcServer;
+
 const DEFAULT_GRPC_PORT: u16 = 8888;
 pub struct GrpcServerBuilder {
     server: Option<
@@ -54,6 +56,14 @@ impl GrpcServerBuilder {
 
     pub fn update_listen_endpoint(&mut self, ip: IpAddr, port: u16) {
         self.listen_address = Some(SocketAddr::new(ip, port));
+    }
+
+    pub fn add_service<S>(&mut self, svc: S)
+    where
+        S: IntoGrpcServer,
+        <S::GrpcServer as my_grpc_extensions::tonic::codegen::Service<Request<Body>>>::Future: Send + 'static,
+    {
+        self.add_grpc_service(svc.into_grpc_server());
     }
 
     pub fn add_grpc_service<S>(&mut self, svc: S)

--- a/service-sdk/src/common/into_grpc_server.rs
+++ b/service-sdk/src/common/into_grpc_server.rs
@@ -1,0 +1,21 @@
+use std::convert::Infallible;
+
+use my_grpc_extensions::tonic::{
+    body::Body,
+    codegen::{http::Request, Service},
+    server::NamedService,
+};
+
+pub trait IntoGrpcServer {
+    type GrpcServer: Service<
+            Request<Body>,
+            Response = my_grpc_extensions::hyper::Response<Body>,
+            Error = Infallible,
+        > + NamedService
+        + Clone
+        + Send
+        + Sync
+        + 'static;
+
+    fn into_grpc_server(self) -> Self::GrpcServer;
+}

--- a/service-sdk/src/common/mod.rs
+++ b/service-sdk/src/common/mod.rs
@@ -1,2 +1,7 @@
 mod service_info;
 pub use service_info::*;
+
+#[cfg(feature = "grpc")]
+mod into_grpc_server;
+#[cfg(feature = "grpc")]
+pub use into_grpc_server::*;


### PR DESCRIPTION
This PR simplifies how to register gRPC services

Previously, we had to create the service implementation and then wrap it into the generated *Server type manually:

```
let grpc_service = GrpcServiceImpl::new(app_context.clone());

service_context.configure_grpc_server(|builder| {
    builder.add_grpc_service(GrpcServiceServer::new(grpc_service.clone()));
});
```

Now we can register the service implementation directly:

```
service_context.configure_grpc_server(|builder| {
    builder.add_service(GrpcServiceImpl::new(app_context.clone()));
});
```

This works when `GrpcServiceImpl` is generated via the `generate_grpc_service` macro, which also implements the `IntoGrpcServer` trait for `GrpcServiceImpl` (so the builder can automatically wrap it into the corresponding *Server type under the hood)